### PR TITLE
Use local Typescript version

### DIFF
--- a/action/action.sh
+++ b/action/action.sh
@@ -2,7 +2,8 @@
 set -e
 
 if [ "${TYPEDOC}" = "true" ]; then
-  typedoc "${GITHUB_WORKSPACE}/src" --out "${GITHUB_WORKSPACE}/docs/generated"
+  npm install typedoc
+  npx typedoc "${GITHUB_WORKSPACE}/src" --out "${GITHUB_WORKSPACE}/docs/generated"
 fi
 
 if [ "${CHANGELOG}" = "true" ]; then

--- a/action/dockerfile
+++ b/action/dockerfile
@@ -10,7 +10,7 @@ RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repo
 RUN pip install awscli
 
 RUN apk add --no-cache bash nodejs npm && chmod +x /action.sh
-RUN npm install -g github-release-notes typescript typedoc
+RUN npm install -g github-release-notes
 
 
 ENTRYPOINT ["/action.sh"]


### PR DESCRIPTION
Install typedoc locally in project instead of globally to fix typescript version mismatches: https://github.com/play-co/gcinstant/runs/1462569477.

Tested with GCInstant.