### PR TITLE
Upgrade `mkdocs-material` for latest extensions support

### DIFF
--- a/action/dockerfile
+++ b/action/dockerfile
@@ -7,7 +7,7 @@ WORKDIR /docs
 
 RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 
-RUN pip install awscli
+RUN pip install -U awscli mkdocs-material
 
 RUN apk add --no-cache bash nodejs npm && chmod +x /action.sh
 RUN npm install -g github-release-notes


### PR DESCRIPTION
Needed for nav bar grouping support in https://github.com/play-co/replicant/pull/1032.