### PR TITLE
Use wheels for Python deps

### DIFF
--- a/action/dockerfile
+++ b/action/dockerfile
@@ -1,5 +1,4 @@
 FROM melopt/mkdocs
-LABEL maintainer="Jake Davies jake.davies@play.company"
 
 COPY action.sh /action.sh
 
@@ -7,6 +6,7 @@ WORKDIR /docs
 
 RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 
+RUN pip install -U pip setuptools wheel
 RUN pip install -U awscli mkdocs-material
 
 RUN apk add --no-cache bash nodejs npm && chmod +x /action.sh


### PR DESCRIPTION
Fixes `packaging.version.InvalidVersion` errors in container build.